### PR TITLE
Refactor and enhance the main file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,12 @@ module gosearch
 
 go 1.23.3
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/ibnaleem/gobreach v0.0.0-20241210003806-81e3b1678889
+	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3
+)
 
 require (
-	github.com/ibnaleem/gobreach v0.0.0-20241210003806-81e3b1678889 // indirect
-	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3 // indirect
 	golang.org/x/crypto v0.29.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/term v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/ibnaleem/gobreach v0.0.0-20241209224324-ea2ab918f0a5 h1:VAN5bPfI+ghTUoV7k/AF9huToTlQWl95u1MnM2e99oU=
-github.com/ibnaleem/gobreach v0.0.0-20241209224324-ea2ab918f0a5/go.mod h1:HklHQ03fEuE/IjFFbIDmscgGQIEFrvgZEey30lrNjnM=
 github.com/ibnaleem/gobreach v0.0.0-20241210003806-81e3b1678889 h1:rUs4h5hESvKNDoC1zIcWq7fqtsCvjUPaY7gzmn3Djdo=
 github.com/ibnaleem/gobreach v0.0.0-20241210003806-81e3b1678889/go.mod h1:HklHQ03fEuE/IjFFbIDmscgGQIEFrvgZEey30lrNjnM=
 github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3 h1:fO9A67/izFYFYky7l1pDP5Dr0BTCRkaQJUG6Jm5ehsk=
@@ -10,7 +8,3 @@ golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.26.0 h1:WEQa6V3Gja/BhNxg540hBip/kkaYtRg3cxg4oXSw4AU=
 golang.org/x/term v0.26.0/go.mod h1:Si5m1o57C5nBNQo5z1iq+XDijt21BDBDp2bK0QI8e3E=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gosearch.go
+++ b/gosearch.go
@@ -86,8 +86,8 @@ type HudsonRockResponse struct {
 
 func UnmarshalJSON() (Data, error) {
 	// GoSearch relies on data.json to determine the websites to search for.
-	// Instead of forcing uers to manually download the data.json file, we will fetch the latest version from the repository.
-	// Thereforeore, we will do the following:
+	// Instead of forcing users to manually download the data.json file, we will fetch the latest version from the repository.
+	// Therefore, we will do the following:
 	// 1. Delete the existing data.json file if it exists as it will be outdated in the future
 	// 2. Read the latest data.json file from the repository
 	// Bonus: it does not download the data.json file, it just reads it from the repository.
@@ -116,7 +116,7 @@ func UnmarshalJSON() (Data, error) {
 	var data Data
 	err = json.Unmarshal(jsonData, &data)
 	if err != nil {
-		return Data{}, fmt.Errorf("error unmarshaling JSON: %w", err)
+		return Data{}, fmt.Errorf("error unmarshalling JSON: %w", err)
 	}
 
 	return data, nil
@@ -209,9 +209,9 @@ func HudsonRock(username string, wg *sync.WaitGroup) {
 		}
 	}
 
-	// For performance reasons, we should not print and write to the file at the same time during a single for-loop interation.
-	// Therefore, there will be 2 for-loop interations: one for printing, and one for writing to the file.
-	// This ensures that GoSearch can print as quickkly as possible since the terminal output is most important.
+	// For performance reasons, we should not print and write to the file at the same time during a single for-loop iteration.
+	// Therefore, there will be 2 for-loop iterations: one for printing, and one for writing to the file.
+	// This ensures that GoSearch can print as quickly as possible since the terminal output is most important.
 
 	for i, stealer := range response.Stealers {
 		WriteToFile(username, fmt.Sprintf("[-] Stealer #%d\n", i+1))
@@ -611,7 +611,7 @@ func main() {
 
 	data, err := UnmarshalJSON()
 	if err != nil {
-		fmt.Printf("Error unmarshaling json: %v\n", err)
+		fmt.Printf("Error unmarshalling json: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/gosearch.go
+++ b/gosearch.go
@@ -255,10 +255,10 @@ func BuildEmail(username string) []string {
 		"@protonmail.com",
 		"@zoho.com",
 		"@msn.com",
-		"proton.me",
-		"onionmail.org",
-		"gmx.de",
-		"mail2world.com",
+		"@proton.me",
+		"@onionmail.org",
+		"@gmx.de",
+		"@mail2world.com",
 	}
 
 	var emails []string

--- a/gosearch.go
+++ b/gosearch.go
@@ -655,6 +655,4 @@ func main() {
 	fmt.Println(strings.Repeat("⎯", 85))
 	fmt.Println(":: Number of profiles found              : ", count)
 	fmt.Println(":: Total time taken                      : ", elapsed)
-
-	os.Exit(0)
 }

--- a/gosearch.go
+++ b/gosearch.go
@@ -35,6 +35,7 @@ const ASCII = `
    \ \_______\ \_______\____\_\  \ \_______\ \__\ \__\ \__\\ _\\ \_______\ \__\ \__\
     \|_______|\|_______|\_________\|_______|\|__|\|__|\|__|\|__|\|_______|\|__|\|__|
                        \|_________|
+
 `
 
 // User-Agent header used in requests.
@@ -616,7 +617,7 @@ func main() {
 	}
 
 	screen.Clear()
-	fmt.Println(ASCII)
+	fmt.Print(ASCII)
 	fmt.Println(VERSION)
 	fmt.Println(strings.Repeat("⎯", 85))
 	fmt.Println(":: Username                              : ", username)

--- a/gosearch.go
+++ b/gosearch.go
@@ -1,22 +1,23 @@
 package main
 
 import (
-	"fmt"
-	"io"
-	"os"
-	"log"
-	"time"
-	"sync"
-	"strings"
-	"net"
-	"net/http"
 	"crypto/tls"
 	"encoding/json"
-	"github.com/inancgumus/screen"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/ibnaleem/gobreach"
+	"github.com/inancgumus/screen"
 )
 
-var Red = "\033[31m" 
+var Red = "\033[31m"
 var Reset = "\033[0m"
 var Green = "\033[32m"
 var Yellow = "\033[33m"
@@ -31,18 +32,18 @@ var ASCII string = `
                        \|_________|
 `
 var VERSION string = "v1.0.0"
-var count uint16 = 0 // Maximum value for count is 65,535
+var count uint16 = 0      // Maximum value for count is 65,535
 var domaincount uint8 = 0 // Maximum value for domaincount is 255
 
 type Website struct {
-	Name             string   `json:"name"`
-	BaseURL          string   `json:"base_url"`
-	URLProbe         string   `json:"url_probe,omitempty"`
-	FollowRedirects  bool     `json:"follow_redirects,omitempty"`
-	ErrorType        string   `json:"errorType"`
-	ErrorMsg         string   `json:"errorMsg,omitempty"`
-	ErrorCode        int      `json:"errorCode,omitempty"`
-	Cookies          []Cookie `json:"cookies,omitempty"`
+	Name            string   `json:"name"`
+	BaseURL         string   `json:"base_url"`
+	URLProbe        string   `json:"url_probe,omitempty"`
+	FollowRedirects bool     `json:"follow_redirects,omitempty"`
+	ErrorType       string   `json:"errorType"`
+	ErrorMsg        string   `json:"errorMsg,omitempty"`
+	ErrorCode       int      `json:"errorCode,omitempty"`
+	Cookies         []Cookie `json:"cookies,omitempty"`
 }
 
 type Data struct {
@@ -55,26 +56,25 @@ type Cookie struct {
 }
 
 type Stealer struct {
-	TotalCorporateServices int      `json:"total_corporate_services"`
-	TotalUserServices      int      `json:"total_user_services"`
-	DateCompromised        string   `json:"date_compromised"`
-	StealerFamily          string   `json:"stealer_family"`
-	ComputerName           string   `json:"computer_name"`
-	OperatingSystem        string   `json:"operating_system"`
-	MalwarePath            string   `json:"malware_path"`
+	TotalCorporateServices int         `json:"total_corporate_services"`
+	TotalUserServices      int         `json:"total_user_services"`
+	DateCompromised        string      `json:"date_compromised"`
+	StealerFamily          string      `json:"stealer_family"`
+	ComputerName           string      `json:"computer_name"`
+	OperatingSystem        string      `json:"operating_system"`
+	MalwarePath            string      `json:"malware_path"`
 	Antiviruses            interface{} `json:"antiviruses"`
-	IP                     string   `json:"ip"`
-	TopPasswords           []string `json:"top_passwords"`
-	TopLogins              []string `json:"top_logins"`
+	IP                     string      `json:"ip"`
+	TopPasswords           []string    `json:"top_passwords"`
+	TopLogins              []string    `json:"top_logins"`
 }
 
 type HudsonRockResponse struct {
-	Message string    `json:"message"`
+	Message  string    `json:"message"`
 	Stealers []Stealer `json:"stealers"`
 }
 
 func UnmarshalJSON() (Data, error) {
-
 	// GoSearch relies on data.json to determine the websites to search for.
 	// Instead of forcing uers to manually download the data.json file, we will fetch the latest version from the repository.
 	// Thereforeore, we will do the following:
@@ -113,7 +113,6 @@ func UnmarshalJSON() (Data, error) {
 }
 
 func WriteToFile(username string, content string) {
-
 	filename := fmt.Sprintf("%s.txt", username)
 
 	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
@@ -132,14 +131,13 @@ func BuildURL(baseURL, username string) string {
 }
 
 func HudsonRock(username string, wg *sync.WaitGroup) {
-
 	defer wg.Done()
 
 	url := "https://cavalier.hudsonrock.com/api/json/v2/osint-tools/search-by-username?username=" + username
 
 	resp, err := http.Get(url)
 	if err != nil {
-		fmt.Println("Error fetching data for " + username + " in HudsonRock function:", err)
+		fmt.Println("Error fetching data for "+username+" in HudsonRock function:", err)
 		return
 	}
 
@@ -172,7 +170,7 @@ func HudsonRock(username string, wg *sync.WaitGroup) {
 			fmt.Println(Red + fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName) + Reset)
 			fmt.Println(Red + fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem) + Reset)
 			fmt.Println(Red + fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath) + Reset)
-			
+
 			switch v := stealer.Antiviruses.(type) {
 			case string:
 				fmt.Println(Red + fmt.Sprintf(":: Antiviruses: %s", v) + Reset)
@@ -183,7 +181,6 @@ func HudsonRock(username string, wg *sync.WaitGroup) {
 				}
 				fmt.Println(Red + fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]) + Reset)
 			}
-			
 
 			fmt.Println(Red + fmt.Sprintf("::  IP: %s", stealer.IP) + Reset)
 
@@ -204,66 +201,64 @@ func HudsonRock(username string, wg *sync.WaitGroup) {
 
 		for i, stealer := range response.Stealers {
 			WriteToFile(username, fmt.Sprintf("[-] Stealer #%d", i+1))
-			WriteToFile(username, fmt.Sprintf("\n::  Stealer Family: %s", stealer.StealerFamily + "\n"))
-			WriteToFile(username, fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised + "\n"))
-			WriteToFile(username, fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName + "\n"))
-			WriteToFile(username, fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem + "\n"))
-			WriteToFile(username, fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath + "\n"))
-			
+			WriteToFile(username, fmt.Sprintf("\n::  Stealer Family: %s", stealer.StealerFamily+"\n"))
+			WriteToFile(username, fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised+"\n"))
+			WriteToFile(username, fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName+"\n"))
+			WriteToFile(username, fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem+"\n"))
+			WriteToFile(username, fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath+"\n"))
+
 			switch v := stealer.Antiviruses.(type) {
 			case string:
-				WriteToFile(username, fmt.Sprintf(":: Antiviruses: %s", v + "\n"))
+				WriteToFile(username, fmt.Sprintf(":: Antiviruses: %s", v+"\n"))
 			case []interface{}:
 				antiviruses := ""
 				for _, av := range v {
 					antiviruses += fmt.Sprintf("%s, ", av)
 				}
-				WriteToFile(username, fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2] + "\n"))
+				WriteToFile(username, fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]+"\n"))
 			}
-			
-			WriteToFile(username, fmt.Sprintf("::  IP: %s", stealer.IP + "\n"))
+
+			WriteToFile(username, fmt.Sprintf("::  IP: %s", stealer.IP+"\n"))
 
 			WriteToFile(username, "[-] Top Passwords:")
 			for _, password := range stealer.TopPasswords {
-				WriteToFile(username, fmt.Sprintf("::    %s", password + "\n"))
+				WriteToFile(username, fmt.Sprintf("::    %s", password+"\n"))
 			}
 
 			WriteToFile(username, "[-] Top Logins:")
 			for _, login := range stealer.TopLogins {
-				WriteToFile(username, fmt.Sprintf("::    %s", login + "\n"))
+				WriteToFile(username, fmt.Sprintf("::    %s", login+"\n"))
 			}
 		}
 	}
 }
 
-
 func BuildEmail(username string) []string {
 	emailDomains := []string{
-			"@gmail.com",
-			"@yahoo.com",
-			"@outlook.com",
-			"@hotmail.com",
-			"@icloud.com",
-			"@aol.com",
-			"@live.com",
-			"@protonmail.com",
-			"@zoho.com",
-			"@msn.com",
-			"proton.me",
-			"onionmail.org",
-			"gmx.de",
-			"mail2world.com",
+		"@gmail.com",
+		"@yahoo.com",
+		"@outlook.com",
+		"@hotmail.com",
+		"@icloud.com",
+		"@aol.com",
+		"@live.com",
+		"@protonmail.com",
+		"@zoho.com",
+		"@msn.com",
+		"proton.me",
+		"onionmail.org",
+		"gmx.de",
+		"mail2world.com",
 	}
 
 	var emails []string
 
 	for _, domain := range emailDomains {
-			emails = append(emails, username + domain)
+		emails = append(emails, username+domain)
 	}
 
 	return emails
 }
-
 
 func BuildDomains(username string) []string {
 	tlds := []string{
@@ -298,7 +293,7 @@ func BuildDomains(username string) []string {
 	var domains []string
 
 	for _, tld := range tlds {
-			domains = append(domains, username + tld)
+		domains = append(domains, username+tld)
 	}
 
 	return domains
@@ -308,7 +303,7 @@ func SearchDomains(username string, domains []string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	client := &http.Client{}
-	fmt.Println(Yellow + "[*] Searching", len(domains), "domains with the username", username, "..." + Reset)
+	fmt.Println(Yellow+"[*] Searching", len(domains), "domains with the username", username, "..."+Reset)
 
 	domaincount := 0
 
@@ -336,47 +331,44 @@ func SearchDomains(username string, domains []string, wg *sync.WaitGroup) {
 		defer resp.Body.Close()
 
 		if resp.StatusCode == 200 {
-			fmt.Println(Green + "[+] 200 OK:", domain + Reset)
+			fmt.Println(Green+"[+] 200 OK:", domain+Reset)
 			domaincount++
 		}
 	}
 
 	if domaincount > 0 {
-		fmt.Println(Green + "[+] Found", domaincount, "domains with the username", username + Reset)
+		fmt.Println(Green+"[+] Found", domaincount, "domains with the username", username+Reset)
 	} else {
-		fmt.Println(Red + "[-] No domains found with the username", username + Reset)
+		fmt.Println(Red+"[-] No domains found with the username", username+Reset)
 	}
 }
 
 func SearchBreachDirectory(emails []string, apikey string, wg *sync.WaitGroup) {
-
 	defer wg.Done()
 
 	// Get an API key (10 lookups for free) @ https://rapidapi.com/rohan-patra/api/breachdirectory
 	client, err := gobreach.NewBreachDirectoryClient(apikey)
-	
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	for _, email := range emails {
-
 		fmt.Println(Yellow + "[*] Searching " + email + " on Breach Directory for any compromised passwords..." + Reset)
-		
+
 		response, err := client.SearchEmail(email)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		if response.Found > 0 {
-			fmt.Printf(Green + "[+] Found %d breaches for %s:\n", response.Found, email + Reset)
+			fmt.Printf(Green+"[+] Found %d breaches for %s:\n", response.Found, email+Reset)
 			for _, entry := range response.Result {
-				fmt.Println(Green + "[+] Password:", entry.Password + Reset)
-				fmt.Println(Green + "[+] SHA1:", entry.Sha1 + Reset)
-				fmt.Println(Green + "[+] Source:", entry.Sources + Reset)
+				fmt.Println(Green+"[+] Password:", entry.Password+Reset)
+				fmt.Println(Green+"[+] SHA1:", entry.Sha1+Reset)
+				fmt.Println(Green+"[+] Source:", entry.Sources+Reset)
 			}
 		} else {
-			fmt.Printf(Red + "[-] No breaches found for %s. Moving on...\n", email + Reset)
+			fmt.Printf(Red+"[-] No breaches found for %s. Moving on...\n", email+Reset)
 		}
 	}
 }
@@ -425,8 +417,8 @@ func MakeRequestWithErrorCode(website Website, url string, username string) {
 	defer res.Body.Close()
 
 	if res.StatusCode != website.ErrorCode {
-		fmt.Println(Green + "[+]", website.Name + ":", url + Reset)
-		WriteToFile(username, url + "\n")
+		fmt.Println(Green+"[+]", website.Name+":", url+Reset)
+		WriteToFile(username, url+"\n")
 		count++
 	}
 }
@@ -487,14 +479,13 @@ func MakeRequestWithErrorMsg(website Website, url string, username string) {
 	bodyStr := string(body)
 	// if the error message is not found in the response body, then the profile exists
 	if !strings.Contains(bodyStr, website.ErrorMsg) {
-		fmt.Println(Green + "[+]", website.Name + ":", url + Reset)
-		WriteToFile(username, url + "\n")
+		fmt.Println(Green+"[+]", website.Name+":", url+Reset)
+		WriteToFile(username, url+"\n")
 		count++
 	}
 }
 
 func MakeRequestWithProfilePresence(website Website, url string, username string) {
-
 	// Some websites have an indicator that a profile exists
 	// but do not have an indicator when a profile does not exist.
 	// If a profile indicator is not found, we can assume that the profile does not exist.
@@ -553,13 +544,13 @@ func MakeRequestWithProfilePresence(website Website, url string, username string
 
 	bodyStr := string(body)
 	// if the profile indicator is found in the response body, the profile exists
-	if strings.Contains(bodyStr, website.ErrorMsg) { 
-		fmt.Println(Green + "[+]", website.Name + ":", url + Reset)
-		WriteToFile(username, url + "\n")
+	if strings.Contains(bodyStr, website.ErrorMsg) {
+		fmt.Println(Green+"[+]", website.Name+":", url+Reset)
+		WriteToFile(username, url+"\n")
 		count++
 	}
-
 }
+
 func Search(data Data, username string, wg *sync.WaitGroup) {
 	var url string
 
@@ -575,13 +566,13 @@ func Search(data Data, username string, wg *sync.WaitGroup) {
 
 			if website.ErrorType == "status_code" {
 				MakeRequestWithErrorCode(website, url, username)
-			} else if website.ErrorType == "errorMsg" {				
+			} else if website.ErrorType == "errorMsg" {
 				MakeRequestWithErrorMsg(website, url, username)
-			} else if website.ErrorType == "profilePresence" {				
+			} else if website.ErrorType == "profilePresence" {
 				MakeRequestWithProfilePresence(website, url, username)
 			} else {
-				fmt.Println(Yellow + "[?]", website.Name + ":", url + Reset)
-                WriteToFile(username, "[?] " + url + "\n")
+				fmt.Println(Yellow+"[?]", website.Name+":", url+Reset)
+				WriteToFile(username, "[?] "+url+"\n")
 				count++
 			}
 		}(website)
@@ -624,17 +615,16 @@ func main() {
 	go HudsonRock(username, &wg)
 	wg.Wait()
 
-
 	if len(os.Args) == 3 {
 		apikey := os.Args[2]
 		fmt.Println(strings.Repeat("⎯", 85))
 		emails := BuildEmail(username)
-    wg.Add(1)
-    go SearchBreachDirectory(emails, apikey, &wg)
-    wg.Wait()
-  }
+		wg.Add(1)
+		go SearchBreachDirectory(emails, apikey, &wg)
+		wg.Wait()
+	}
 
-    domains := BuildDomains(username)
+	domains := BuildDomains(username)
 	fmt.Println(strings.Repeat("⎯", 85))
 	wg.Add(1)
 	go SearchDomains(username, domains, &wg)
@@ -644,6 +634,6 @@ func main() {
 	fmt.Println(strings.Repeat("⎯", 85))
 	fmt.Println(":: Number of profiles found              : ", count)
 	fmt.Println(":: Total time taken                      : ", elapsed)
-	
+
 	os.Exit(0)
 }

--- a/gosearch.go
+++ b/gosearch.go
@@ -176,24 +176,27 @@ func HudsonRock(username string, wg *sync.WaitGroup) {
 
 	for i, stealer := range response.Stealers {
 		fmt.Println(Red + fmt.Sprintf("[-] Stealer #%d", i+1) + Reset)
-		fmt.Println(Red + fmt.Sprintf("::  Stealer Family: %s", stealer.StealerFamily) + Reset)
-		fmt.Println(Red + fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised) + Reset)
-		fmt.Println(Red + fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName) + Reset)
-		fmt.Println(Red + fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem) + Reset)
-		fmt.Println(Red + fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::    Stealer Family: %s", stealer.StealerFamily) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::    Date Compromised: %s", stealer.DateCompromised) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::    Computer Name: %s", stealer.ComputerName) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::    Operating System: %s", stealer.OperatingSystem) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::    Malware Path: %s", stealer.MalwarePath) + Reset)
 
 		switch v := stealer.Antiviruses.(type) {
 		case string:
-			fmt.Println(Red + fmt.Sprintf(":: Antiviruses: %s", v) + Reset)
+			WriteToFile(username, fmt.Sprintf("::    Antiviruses: %s\n", v))
 		case []interface{}:
-			antiviruses := ""
-			for _, av := range v {
-				antiviruses += fmt.Sprintf("%s, ", av)
+			antiviruses := make([]string, len(v))
+
+			for i, av := range v {
+				antiviruses[i] = fmt.Sprint(av)
 			}
-			fmt.Println(Red + fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]) + Reset)
+
+			avs := strings.Join(antiviruses, ", ")
+			WriteToFile(username, fmt.Sprintf("::    Antiviruses: %s\n", avs))
 		}
 
-		fmt.Println(Red + fmt.Sprintf("::  IP: %s", stealer.IP) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::    IP: %s", stealer.IP) + Reset)
 
 		fmt.Println(Red + "[-] Top Passwords:" + Reset)
 		for _, password := range stealer.TopPasswords {
@@ -211,34 +214,37 @@ func HudsonRock(username string, wg *sync.WaitGroup) {
 	// This ensures that GoSearch can print as quickkly as possible since the terminal output is most important.
 
 	for i, stealer := range response.Stealers {
-		WriteToFile(username, fmt.Sprintf("[-] Stealer #%d", i+1))
-		WriteToFile(username, fmt.Sprintf("\n::  Stealer Family: %s", stealer.StealerFamily+"\n"))
-		WriteToFile(username, fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised+"\n"))
-		WriteToFile(username, fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName+"\n"))
-		WriteToFile(username, fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem+"\n"))
-		WriteToFile(username, fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath+"\n"))
+		WriteToFile(username, fmt.Sprintf("[-] Stealer #%d\n", i+1))
+		WriteToFile(username, fmt.Sprintf("::    Stealer Family: %s\n", stealer.StealerFamily))
+		WriteToFile(username, fmt.Sprintf("::    Date Compromised: %s\n", stealer.DateCompromised))
+		WriteToFile(username, fmt.Sprintf("::    Computer Name: %s\n", stealer.ComputerName))
+		WriteToFile(username, fmt.Sprintf("::    Operating System: %s\n", stealer.OperatingSystem))
+		WriteToFile(username, fmt.Sprintf("::    Malware Path: %s\n", stealer.MalwarePath))
 
 		switch v := stealer.Antiviruses.(type) {
 		case string:
-			WriteToFile(username, fmt.Sprintf(":: Antiviruses: %s", v+"\n"))
+			WriteToFile(username, fmt.Sprintf("::    Antiviruses: %s\n", v))
 		case []interface{}:
-			antiviruses := ""
-			for _, av := range v {
-				antiviruses += fmt.Sprintf("%s, ", av)
+			antiviruses := make([]string, len(v))
+
+			for i, av := range v {
+				antiviruses[i] = fmt.Sprint(av)
 			}
-			WriteToFile(username, fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]+"\n"))
+
+			avs := strings.Join(antiviruses, ", ")
+			WriteToFile(username, fmt.Sprintf("::    Antiviruses: %s\n", avs))
 		}
 
-		WriteToFile(username, fmt.Sprintf("::  IP: %s", stealer.IP+"\n"))
+		WriteToFile(username, fmt.Sprintf("::    IP: %s\n", stealer.IP))
 
-		WriteToFile(username, "[-] Top Passwords:")
+		WriteToFile(username, "[-] Top Passwords:\n")
 		for _, password := range stealer.TopPasswords {
-			WriteToFile(username, fmt.Sprintf("::    %s", password+"\n"))
+			WriteToFile(username, fmt.Sprintf("::    %s\n", password))
 		}
 
-		WriteToFile(username, "[-] Top Logins:")
+		WriteToFile(username, "[-] Top Logins:\n")
 		for _, login := range stealer.TopLogins {
-			WriteToFile(username, fmt.Sprintf("::    %s", login+"\n"))
+			WriteToFile(username, fmt.Sprintf("::    %s\n", login))
 		}
 	}
 }

--- a/gosearch.go
+++ b/gosearch.go
@@ -26,7 +26,7 @@ const (
 )
 
 // GoSearch ASCII logo.
-const ASCII string = `
+const ASCII = `
  ________  ________  ________  _______   ________  ________  ________  ___  ___     
 |\   ____\|\   __  \|\   ____\|\  ___ \ |\   __  \|\   __  \|\   ____\|\  \|\  \    
 \ \  \___|\ \  \|\  \ \  \___|\ \   __/|\ \  \|\  \ \  \|\  \ \  \___|\ \  \\\  \   
@@ -41,7 +41,7 @@ const ASCII string = `
 const UserAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0"
 
 // GoSearch version.
-const VERSION string = "v1.0.0"
+const VERSION = "v1.0.0"
 
 var count uint16 = 0 // Maximum value for count is 65,535
 
@@ -606,7 +606,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var username string = os.Args[1]
+	var username = os.Args[1]
 	var wg sync.WaitGroup
 
 	data, err := UnmarshalJSON()

--- a/gosearch.go
+++ b/gosearch.go
@@ -115,14 +115,14 @@ func UnmarshalJSON() (Data, error) {
 func WriteToFile(username string, content string) {
 	filename := fmt.Sprintf("%s.txt", username)
 
-	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, os.ModePerm)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	defer f.Close()
 
 	if _, err = f.WriteString(content); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 

--- a/gosearch.go
+++ b/gosearch.go
@@ -170,75 +170,75 @@ func HudsonRock(username string, wg *sync.WaitGroup) {
 		fmt.Println(Green + ":: This username is not associated with a computer infected by an info-stealer." + Reset)
 		WriteToFile(username, ":: This username is not associated with a computer infected by an info-stealer.")
 		return
-	} else {
-		fmt.Println(Red + ":: This username is associated with a computer that was infected by an info-stealer, all the credentials saved on this computer are at risk of being accessed by cybercriminals." + Reset)
+	}
 
-		for i, stealer := range response.Stealers {
-			fmt.Println(Red + fmt.Sprintf("[-] Stealer #%d", i+1) + Reset)
-			fmt.Println(Red + fmt.Sprintf("::  Stealer Family: %s", stealer.StealerFamily) + Reset)
-			fmt.Println(Red + fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised) + Reset)
-			fmt.Println(Red + fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName) + Reset)
-			fmt.Println(Red + fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem) + Reset)
-			fmt.Println(Red + fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath) + Reset)
+	fmt.Println(Red + ":: This username is associated with a computer that was infected by an info-stealer, all the credentials saved on this computer are at risk of being accessed by cybercriminals." + Reset)
 
-			switch v := stealer.Antiviruses.(type) {
-			case string:
-				fmt.Println(Red + fmt.Sprintf(":: Antiviruses: %s", v) + Reset)
-			case []interface{}:
-				antiviruses := ""
-				for _, av := range v {
-					antiviruses += fmt.Sprintf("%s, ", av)
-				}
-				fmt.Println(Red + fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]) + Reset)
+	for i, stealer := range response.Stealers {
+		fmt.Println(Red + fmt.Sprintf("[-] Stealer #%d", i+1) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::  Stealer Family: %s", stealer.StealerFamily) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName) + Reset)
+		fmt.Println(Red + fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem) + Reset)
+		fmt.Println(Red + fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath) + Reset)
+
+		switch v := stealer.Antiviruses.(type) {
+		case string:
+			fmt.Println(Red + fmt.Sprintf(":: Antiviruses: %s", v) + Reset)
+		case []interface{}:
+			antiviruses := ""
+			for _, av := range v {
+				antiviruses += fmt.Sprintf("%s, ", av)
 			}
-
-			fmt.Println(Red + fmt.Sprintf("::  IP: %s", stealer.IP) + Reset)
-
-			fmt.Println(Red + "[-] Top Passwords:" + Reset)
-			for _, password := range stealer.TopPasswords {
-				fmt.Println(Red + fmt.Sprintf("::    %s", password) + Reset)
-			}
-
-			fmt.Println(Red + "[-] Top Logins:" + Reset)
-			for _, login := range stealer.TopLogins {
-				fmt.Println(Red + fmt.Sprintf("::    %s", login) + Reset)
-			}
+			fmt.Println(Red + fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]) + Reset)
 		}
 
-		// For performance reasons, we should not print and write to the file at the same time during a single for-loop interation.
-		// Therefore, there will be 2 for-loop interations: one for printing, and one for writing to the file.
-		// This ensures that GoSearch can print as quickkly as possible since the terminal output is most important.
+		fmt.Println(Red + fmt.Sprintf("::  IP: %s", stealer.IP) + Reset)
 
-		for i, stealer := range response.Stealers {
-			WriteToFile(username, fmt.Sprintf("[-] Stealer #%d", i+1))
-			WriteToFile(username, fmt.Sprintf("\n::  Stealer Family: %s", stealer.StealerFamily+"\n"))
-			WriteToFile(username, fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised+"\n"))
-			WriteToFile(username, fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName+"\n"))
-			WriteToFile(username, fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem+"\n"))
-			WriteToFile(username, fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath+"\n"))
+		fmt.Println(Red + "[-] Top Passwords:" + Reset)
+		for _, password := range stealer.TopPasswords {
+			fmt.Println(Red + fmt.Sprintf("::    %s", password) + Reset)
+		}
 
-			switch v := stealer.Antiviruses.(type) {
-			case string:
-				WriteToFile(username, fmt.Sprintf(":: Antiviruses: %s", v+"\n"))
-			case []interface{}:
-				antiviruses := ""
-				for _, av := range v {
-					antiviruses += fmt.Sprintf("%s, ", av)
-				}
-				WriteToFile(username, fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]+"\n"))
+		fmt.Println(Red + "[-] Top Logins:" + Reset)
+		for _, login := range stealer.TopLogins {
+			fmt.Println(Red + fmt.Sprintf("::    %s", login) + Reset)
+		}
+	}
+
+	// For performance reasons, we should not print and write to the file at the same time during a single for-loop interation.
+	// Therefore, there will be 2 for-loop interations: one for printing, and one for writing to the file.
+	// This ensures that GoSearch can print as quickkly as possible since the terminal output is most important.
+
+	for i, stealer := range response.Stealers {
+		WriteToFile(username, fmt.Sprintf("[-] Stealer #%d", i+1))
+		WriteToFile(username, fmt.Sprintf("\n::  Stealer Family: %s", stealer.StealerFamily+"\n"))
+		WriteToFile(username, fmt.Sprintf("::  Date Compromised: %s", stealer.DateCompromised+"\n"))
+		WriteToFile(username, fmt.Sprintf("::  Computer Name: %s", stealer.ComputerName+"\n"))
+		WriteToFile(username, fmt.Sprintf(":: Operating System: %s", stealer.OperatingSystem+"\n"))
+		WriteToFile(username, fmt.Sprintf("::  Malware Path: %s", stealer.MalwarePath+"\n"))
+
+		switch v := stealer.Antiviruses.(type) {
+		case string:
+			WriteToFile(username, fmt.Sprintf(":: Antiviruses: %s", v+"\n"))
+		case []interface{}:
+			antiviruses := ""
+			for _, av := range v {
+				antiviruses += fmt.Sprintf("%s, ", av)
 			}
+			WriteToFile(username, fmt.Sprintf("::  Antiviruses: %s", antiviruses[:len(antiviruses)-2]+"\n"))
+		}
 
-			WriteToFile(username, fmt.Sprintf("::  IP: %s", stealer.IP+"\n"))
+		WriteToFile(username, fmt.Sprintf("::  IP: %s", stealer.IP+"\n"))
 
-			WriteToFile(username, "[-] Top Passwords:")
-			for _, password := range stealer.TopPasswords {
-				WriteToFile(username, fmt.Sprintf("::    %s", password+"\n"))
-			}
+		WriteToFile(username, "[-] Top Passwords:")
+		for _, password := range stealer.TopPasswords {
+			WriteToFile(username, fmt.Sprintf("::    %s", password+"\n"))
+		}
 
-			WriteToFile(username, "[-] Top Logins:")
-			for _, login := range stealer.TopLogins {
-				WriteToFile(username, fmt.Sprintf("::    %s", login+"\n"))
-			}
+		WriteToFile(username, "[-] Top Logins:")
+		for _, login := range stealer.TopLogins {
+			WriteToFile(username, fmt.Sprintf("::    %s", login+"\n"))
 		}
 	}
 }
@@ -329,13 +329,16 @@ func SearchDomains(username string, domains []string, wg *sync.WaitGroup) {
 
 		resp, err := client.Do(req)
 		if err != nil {
-			if strings.Contains(err.Error(), "no such host") {
-				continue // this means the domain doesn't exist
-			} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				continue // this also means the domain doesn't exist
-			} else {
+			netErr, ok := err.(net.Error)
+
+			// The following errors mean that the domain does not exist.
+			noSuchHostError := strings.Contains(err.Error(), "no such host")
+			networkTimeoutError := ok && netErr.Timeout()
+
+			if !noSuchHostError && !networkTimeoutError {
 				fmt.Printf("Error sending request for %s: %v\n", domain, err)
 			}
+
 			continue
 		}
 		defer resp.Body.Close()
@@ -575,13 +578,14 @@ func Search(data Data, username string, wg *sync.WaitGroup) {
 				url = BuildURL(website.BaseURL, username)
 			}
 
-			if website.ErrorType == "status_code" {
+			switch website.ErrorType {
+			case "status_code":
 				MakeRequestWithErrorCode(website, url, username)
-			} else if website.ErrorType == "errorMsg" {
+			case "errorMsg":
 				MakeRequestWithErrorMsg(website, url, username)
-			} else if website.ErrorType == "profilePresence" {
+			case "profilePresence":
 				MakeRequestWithProfilePresence(website, url, username)
-			} else {
+			default:
 				fmt.Println(Yellow+"[?]", website.Name+":", url+Reset)
 				WriteToFile(username, "[?] "+url+"\n")
 				count++

--- a/gosearch.go
+++ b/gosearch.go
@@ -17,11 +17,16 @@ import (
 	"github.com/inancgumus/screen"
 )
 
-var Red = "\033[31m"
-var Reset = "\033[0m"
-var Green = "\033[32m"
-var Yellow = "\033[33m"
-var ASCII string = `
+// Color output constants.
+const (
+	Red    = "\033[31m"
+	Reset  = "\033[0m"
+	Green  = "\033[32m"
+	Yellow = "\033[33m"
+)
+
+// GoSearch ASCII logo.
+const ASCII string = `
  ________  ________  ________  _______   ________  ________  ________  ___  ___     
 |\   ____\|\   __  \|\   ____\|\  ___ \ |\   __  \|\   __  \|\   ____\|\  \|\  \    
 \ \  \___|\ \  \|\  \ \  \___|\ \   __/|\ \  \|\  \ \  \|\  \ \  \___|\ \  \\\  \   
@@ -31,9 +36,14 @@ var ASCII string = `
     \|_______|\|_______|\_________\|_______|\|__|\|__|\|__|\|__|\|_______|\|__|\|__|
                        \|_________|
 `
-var VERSION string = "v1.0.0"
-var count uint16 = 0      // Maximum value for count is 65,535
-var domaincount uint8 = 0 // Maximum value for domaincount is 255
+
+// User-Agent header used in requests.
+const UserAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0"
+
+// GoSearch version.
+const VERSION string = "v1.0.0"
+
+var count uint16 = 0 // Maximum value for count is 65,535
 
 type Website struct {
 	Name            string   `json:"name"`
@@ -310,12 +320,12 @@ func SearchDomains(username string, domains []string, wg *sync.WaitGroup) {
 	for _, domain := range domains {
 		url := "http://" + domain
 
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
 			fmt.Printf("Error creating request for %s: %v\n", domain, err)
 			continue
 		}
-		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0")
+		req.Header.Set("User-Agent", UserAgent)
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -330,7 +340,7 @@ func SearchDomains(username string, domains []string, wg *sync.WaitGroup) {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode == 200 {
+		if resp.StatusCode == http.StatusOK {
 			fmt.Println(Green+"[+] 200 OK:", domain+Reset)
 			domaincount++
 		}
@@ -392,13 +402,13 @@ func MakeRequestWithErrorCode(website Website, url string, username string) {
 		}
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		fmt.Printf("Error creating request in function MakeRequestWithErrorCode: %v\n", err)
 		return
 	}
 
-	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0")
+	req.Header.Set("User-Agent", UserAgent)
 
 	if website.Cookies != nil {
 		for _, cookie := range website.Cookies {
@@ -442,13 +452,13 @@ func MakeRequestWithErrorMsg(website Website, url string, username string) {
 		}
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		fmt.Printf("Error creating request in function MakeRequestWithErrorMsg: %v\n", err)
 		return
 	}
 
-	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0")
+	req.Header.Set("User-Agent", UserAgent)
 
 	if website.Cookies != nil {
 		for _, cookie := range website.Cookies {
@@ -508,13 +518,13 @@ func MakeRequestWithProfilePresence(website Website, url string, username string
 		}
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		fmt.Printf("Error creating request in function MakeRequestWithErrorMsg: %v\n", err)
 		return
 	}
 
-	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0")
+	req.Header.Set("User-Agent", UserAgent)
 
 	if website.Cookies != nil {
 		for _, cookie := range website.Cookies {

--- a/gosearch.go
+++ b/gosearch.go
@@ -360,15 +360,16 @@ func SearchBreachDirectory(emails []string, apikey string, wg *sync.WaitGroup) {
 			log.Fatal(err)
 		}
 
-		if response.Found > 0 {
-			fmt.Printf(Green+"[+] Found %d breaches for %s:\n", response.Found, email+Reset)
-			for _, entry := range response.Result {
-				fmt.Println(Green+"[+] Password:", entry.Password+Reset)
-				fmt.Println(Green+"[+] SHA1:", entry.Sha1+Reset)
-				fmt.Println(Green+"[+] Source:", entry.Sources+Reset)
-			}
-		} else {
+		if response.Found == 0 {
 			fmt.Printf(Red+"[-] No breaches found for %s. Moving on...\n", email+Reset)
+			continue
+		}
+
+		fmt.Printf(Green+"[+] Found %d breaches for %s:\n", response.Found, email+Reset)
+		for _, entry := range response.Result {
+			fmt.Println(Green+"[+] Password:", entry.Password+Reset)
+			fmt.Println(Green+"[+] SHA1:", entry.Sha1+Reset)
+			fmt.Println(Green+"[+] Source:", entry.Sources+Reset)
 		}
 	}
 }


### PR DESCRIPTION
Like #19, this PR adds some fixes and refactoring, to the main file `gosearch.go`.

The following changes were made:

1. Reformat the code using `go fmt`
2. Use built-in constants instead of hardcoded strings
3. Remove redundant `os.Exit` call at the end of `main`
4. Reduce cyclomatic complexity of `HudsonRock`
5. Make output of `HudsonRock` more consistent
6. Add missing `@` chars to email domains
7. Remove redundant types where they can be inferred
8. Run `go mod tidy` to ensure that `go.mod` reflects the actual dependencies required
9. Fix some typos

I am not sure about 5, i.e. the output of `HudsonRock` (commit 0edf5ba7a62207d3bc8c797b514134e24257e130) though.

I assumed that the following output format was intended:

```
[-] Stealer #1
::    Stealer Family: Vidar
::    Date Compromised: 2020-11-26T20:10:58.000Z
::    Computer Name: DESKTOP-LUL8SFS
::    Operating System: Windows 10 Pro [x64]
::    Malware Path:  C:\Users\NotBroo\AppData\Local\Temp\{8n8j-FwSyp-04oo-XwjBT}\83159816503.exe
::    IP: 93.146.**.***
[-] Top Passwords:
::    R**********5
::    C**********1
::    p*********o
::    L*************4
::    F*************5
[-] Top Logins:
::    c*******@gmail.com
::    m********o
::    c*********@gmail.com
::    c*********@gmail.com
::    m************@gmail.com
```

Basically, this commit adds consistent left padding for the details of stealer.