### PR TITLE
docs: correct installation path for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ For Unix:
 ```
 $ ./gosearch <username>
 ```
-I recommend adding the `gosearch` binary to your `/bin` for universal use:
+I recommend adding the `gosearch` binary to your `/usr/local/bin` for universal use:
 ```
-$ sudo mv gosearch ~/usr/bin
+# mv gosearch /usr/local/bin
 ```
 For Windows:
 ```


### PR DESCRIPTION
Replace `~/usr/bin` with `/usr/local/bin` in the recommended installation instructions. Also replace `$ sudo` with `#` indicating that the command must be executed as root for consistency.