### PR TITLE
Fix false positives for figma.com

### DIFF
--- a/data.json
+++ b/data.json
@@ -389,7 +389,7 @@
       "base_url": "https://www.figma.com/@{}",
       "follow_redirects": true,
       "errorType": "status_code",
-      "errorCode": 202
+      "errorCode": 404
     },
     {
       "name": "Linktree",


### PR DESCRIPTION
Fixes #30 by changing `errorCode` to `404`.

For some reason though, when making multiple requests to `https://www.figma.com/@{}`, it starts returning an empty body with status code of `202 Accepted` for both existing and non-existing profiles. After a short timeout (about 5 minutes) it returns `200 OK` for existing profiles and `404 Not Found` for non-existing profiles.

Here is an output from the testing binary for each case described:

1.  Profile exists:

    ```
    [*] Testing URL: https://www.figma.com/@some
    [*] Mode: 1 (Response Body)
    [+] Response: 200 OK
    [+] Response URL: https://www.figma.com/@some
    [+] Saved response to response.txt
    ```

2.  Profile does not exist:

    ```
    [*] Testing URL: https://www.figma.com/@rgferkmgklregjrelkgjergkljrg
    [*] Mode: 1 (Response Body)
    [+] Response: 404 Not Found
    [+] Response URL: https://www.figma.com/@rgferkmgklregjrelkgjergkljrg
    [+] Saved response to response.txt
    ```

3.  Profile does not exist, immediately after `2`:

    ```
    [*] Testing URL: https://www.figma.com/@rgferkmgklregjrelkgjergkljrg
    [*] Mode: 1 (Response Body)
    [+] Response: 202 Accepted
    [+] Response URL: https://www.figma.com/@rgferkmgklregjrelkgjergkljrg
    [+] Saved response to response.txt
    ```
4. Profile exists, immediately after `3`:

   ```
   [*] Testing URL: https://www.figma.com/@some
   [*] Mode: 1 (Response Body)
   [+] Response: 202 Accepted
   [+] Response URL: https://www.figma.com/@some
   [+] Saved response to response.txt
   ```

5. Profile does not exist, with timeout of 5 minutes after `4`:

   ```
   [*] Testing URL: https://www.figma.com/@rgferkmgklregjrelkgjergkljrg
   [*] Mode: 1 (Response Body)
   [+] Response: 404 Not Found
   [+] Response URL: https://www.figma.com/@rgferkmgklregjrelkgjergkljrg
   [+] Saved response to response.txt
   ```