### PR TITLE
allow go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ For Windows:
 ```
 C:\Users\***\gosearch> gosearch.exe <username>
 ```
+Install using go:
+```
+$ go install github.com/ibnaleem/gosearch@latest
+```
 ## Use Cases
 GoSearch allows you to search [breachdirectory.org](https://breachdirectory.org) for compromised passwords associated with a specific username. To fully utilise GoSearch, follow these steps:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gosearch
+module github.com/ibnaleem/gosearch
 
 go 1.23.3
 


### PR DESCRIPTION
I want to use `go install` for installation. This pull request makes it possible and ensures nothing breaks.  

Test it here:  
`go install github.com/CptIdea/gosearch@06a30aa`  
(Note: This commit is not part of the pull request, it's just for testing.)  

