### PR TITLE
Correct JSON field for eyeem.com

### DIFF
--- a/data.json
+++ b/data.json
@@ -1088,7 +1088,7 @@
     },
     {
       "name": "EyeEm",
-      "url": "https://www.eyeem.com/u/{}",
+      "base_url": "https://www.eyeem.com/u/{}",
       "follow_redirects": true,
       "errorType": "status_code",
       "errorCode": 404


### PR DESCRIPTION
Replace `url` with `base_url` for EyeEm to fix empty URL resulting in `Error making GET request to : Get "": unsupported protocol scheme ""`