### PR TITLE
Url Probe Fix

### DIFF
--- a/gosearch.go
+++ b/gosearch.go
@@ -504,6 +504,7 @@ func MakeRequestWithErrorCode(website Website, url string, username string) {
 	defer res.Body.Close()
 
 	if res.StatusCode != website.ErrorCode {
+		url = BuildURL(website.BaseURL, username)
 		fmt.Println(Green+"[+]", website.Name+":", url+Reset)
 		WriteToFile(username, url+"\n")
 		count.Add(1)

--- a/gosearch.go
+++ b/gosearch.go
@@ -563,6 +563,7 @@ func MakeRequestWithErrorMsg(website Website, url string, username string) {
 	bodyStr := string(body)
 	// if the error message is not found in the response body, then the profile exists
 	if !strings.Contains(bodyStr, website.ErrorMsg) {
+		url = BuildURL(website.BaseURL, username)
 		fmt.Println(Green+"[+]", website.Name+":", url+Reset)
 		WriteToFile(username, url+"\n")
 		count.Add(1)

--- a/gosearch.go
+++ b/gosearch.go
@@ -623,10 +623,6 @@ func MakeRequestWithProfilePresence(website Website, url string, username string
 		return
 	}
 
-	if website.URLProbe != "" {
-		url = BuildURL(website.BaseURL, username)
-	}
-
 	bodyStr := string(body)
 	// if the profile indicator is found in the response body, the profile exists
 	if strings.Contains(bodyStr, website.ErrorMsg) {

--- a/gosearch.go
+++ b/gosearch.go
@@ -560,10 +560,6 @@ func MakeRequestWithErrorMsg(website Website, url string, username string) {
 		return
 	}
 
-	if website.URLProbe != "" {
-		url = BuildURL(website.BaseURL, username)
-	}
-
 	bodyStr := string(body)
 	// if the error message is not found in the response body, then the profile exists
 	if !strings.Contains(bodyStr, website.ErrorMsg) {


### PR DESCRIPTION
Some websites provide an API endpoint for querying usernames (`url_probe`), but this API URL should not be displayed to the users. This PR addresses the issue by reassigning the `url` variable within each function to the `base_url` after constructing the profile path. This ensures that the output reflects the actual location of the profile rather than the API endpoint.
#### Previous Output
```
[+] Duolingo: https://www.duolingo.com/2017-06-30/users?username=jake
```
#### New Output
```
[+] Duolingo: https://www.duolingo.com/profile/jake
```
This change aligns with GoSearch's mission, which is not only to identify existing profiles but also to show users where the profiles are hosted.