### PR TITLE
Remove old user summary file

### DIFF
--- a/gosearch.go
+++ b/gosearch.go
@@ -601,7 +601,7 @@ func Search(data Data, username string, wg *sync.WaitGroup) {
 	}
 }
 
-func deleteOldFile(username string) {
+func DeleteOldFile(username string) {
     filename := fmt.Sprintf("%s.txt", username)
     _ = os.Remove(filename)
 }

--- a/gosearch.go
+++ b/gosearch.go
@@ -601,6 +601,11 @@ func Search(data Data, username string, wg *sync.WaitGroup) {
 	}
 }
 
+func deleteOldFile(username string) {
+    filename := fmt.Sprintf("%s.txt", username)
+    _ = os.Remove(filename)
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: gosearch <username>\nIssues: https://github.com/ibnaleem/gosearch/issues")
@@ -608,6 +613,7 @@ func main() {
 	}
 
 	var username = os.Args[1]
+	deleteOldFile(username)
 	var wg sync.WaitGroup
 
 	data, err := UnmarshalJSON()


### PR DESCRIPTION
Remove old summary file if the user has been searched already.
Current approach works in such way that if you've previously searched for this user and .txt file is still present in the folder -- when you're searching again, you're appending the text which leads to duplication.
Example:
![image](https://github.com/user-attachments/assets/f27877a5-2ca7-417b-b33d-d4d67628d888)
The purpose of this PR is to prevent it.