### PR TITLE
Fix false false positives for `app.daily.dev`

### DIFF
--- a/data.json
+++ b/data.json
@@ -459,8 +459,8 @@
       "name": "Daily.dev",
       "base_url": "https://app.daily.dev/{}",
       "follow_redirects": true,
-      "errorType": "errorMsg",
-      "errorMsg": "Page not found"
+      "errorType": "profilePresence",
+      "errorMsg": "{\"props\":{\"pageProps\":{\"user\":{\"id\":"
     },
     {
       "name": "HackerNews",


### PR DESCRIPTION
Fixes #27 by changing error type to `profilePresense`. See [my comment](https://github.com/ibnaleem/gosearch/issues/27#issuecomment-2599846957) on #27 for details.