### PR TITLE
Enhance profile existence verification with ResponseURL

### DIFF
--- a/gosearch.go
+++ b/gosearch.go
@@ -57,6 +57,7 @@ type Website struct {
 	ErrorType       string   `json:"errorType"`
 	ErrorMsg        string   `json:"errorMsg,omitempty"`
 	ErrorCode       int      `json:"errorCode,omitempty"`
+	ResponseURL     string   `json:"response_url,omitempty"`
 	Cookies         []Cookie `json:"cookies,omitempty"`
 }
 

--- a/gosearch.go
+++ b/gosearch.go
@@ -705,6 +705,8 @@ func Search(data Data, username string, wg *sync.WaitGroup) {
 				MakeRequestWithErrorMsg(website, url, username)
 			case "profilePresence":
 				MakeRequestWithProfilePresence(website, url, username)
+			case "response_url":
+				MakeRequestWithResponseURL(website, url, username)
 			default:
 				fmt.Println(Yellow+"[?]", website.Name+":", url+Reset)
 				WriteToFile(username, "[?] "+url+"\n")


### PR DESCRIPTION
**Purpose:**  
Mitigate false positives in profile existence checks by evaluating response URLs, particularly for websites with ambiguous redirect behavior.  

**Changes:**  
- **feat(struct) ([`b888325`](https://github.com/ibnaleem/gosearch/commit/b888325392825162a054e28664f96f75f53ea539)):** Add `ResponseURL` field to `Website` struct to define expected profile URL template.  
- **feat(response) ([`fe9cb31`](https://github.com/ibnaleem/gosearch/commit/fe9cb31612283ab2d1a0a5c51f86ec2bdf49998c)):** Implement `MakeRequestWithResponseURL` to validate profiles by comparing the resolved response URL against `ResponseURL`.  
- **feat(case) ([`f798a6f`](https://github.com/ibnaleem/gosearch/commit/f798a6fe4bfdb59aaae001c36a029b56e936851c)):** Integrate `response_url` case handling to leverage the new verification logic.  

**Key Implementation Details:**  
- **Redirect Handling:** When `FollowRedirects` is disabled, the response URL is analyzed to determine if it aligns with the expected profile structure (built via `BuildURL`).  
- **Logic Flow:**  
  - If the resolved response URL **does not match** the formatted `ResponseURL`, the profile is flagged as valid (indicating no redirection to a non-profile endpoint).  
  - Cookies, custom user agents, and TLS configurations are preserved for compatibility.  

**Notes:**  
- Maintains backward compatibility with existing `Website` struct configurations.  
- Does not alter core request logic; supplements validation for ambiguous cases.  

--- 

**Code Snippet (Simplified):**  
```go
if !(res.Request.URL.String() == formattedResponseURL) {
    // Profile deemed valid if response URL mismatches expected structure
    fmt.Println(Green + "[+] Profile found: " + url)
}
```  

This PR introduces no breaking changes and enhances detection accuracy for edge-case platforms.