### PR TITLE
Feature: Report Only Positives

### DIFF
--- a/gosearch.go
+++ b/gosearch.go
@@ -793,7 +793,7 @@ func main() {
 	usernameFlagLong := flag.String("username", "", "Username to search")
 	noFalsePositivesFlag := flag.Bool("no-false-positives", false, "Do not show false positives")
 	breachDirectoryAPIKey := flag.String("b", "", "Search Breach Directory with an API Key")
-	breachDirectoryAPIKeyLong := flag.String("breach-directory-api-key", "", "Search Breach Directory with an API Key")
+	breachDirectoryAPIKeyLong := flag.String("breach-directory", "", "Search Breach Directory with an API Key")
 
 	flag.Parse()
 

--- a/gosearch.go
+++ b/gosearch.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	"crypto/tls"
-	"fmt"
 	"io"
+	"os"
+	"fmt"
 	"log"
 	"net"
-	"net/http"
-	"os"
-	"strconv"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
+	"strings"
+	"strconv"
+	"net/http"
+	"crypto/tls"
+	"sync/atomic"
 
 	"github.com/bytedance/sonic"
 	"github.com/ibnaleem/gobreach"

--- a/gosearch.go
+++ b/gosearch.go
@@ -745,7 +745,7 @@ func MakeRequestWithProfilePresence(website Website, url string, username string
 	}
 }
 
-func Search(data Data, username string, wg *sync.WaitGroup) {
+func Search(data Data, username string, noFalsePositives bool, wg *sync.WaitGroup) {
 	for _, website := range data.Websites {
 		go func(website Website) {
 			var url string
@@ -768,9 +768,12 @@ func Search(data Data, username string, wg *sync.WaitGroup) {
 			case "response_url":
 				MakeRequestWithResponseURL(website, url, username)
 			default:
-				fmt.Println(Yellow+"[?]", website.Name+":", url+Reset)
-				WriteToFile(username, "[?] "+url+"\n")
-				count.Add(1)
+				// if false positives are disabled, then we can print false positives
+				if !noFalsePositives {
+					fmt.Println(Yellow+"[?]", website.Name+":", url+Reset)
+					WriteToFile(username, "[?] "+url+"\n")
+					count.Add(1)
+				}
 			}
 		}(website)
 	}
@@ -838,7 +841,7 @@ func main() {
 	start := time.Now()
 
 	wg.Add(len(data.Websites))
-	go Search(data, username, &wg)
+	go Search(data, username, *noFalsePositivesFlag, &wg)
 	wg.Wait()
 
 	wg.Add(1)

--- a/gosearch.go
+++ b/gosearch.go
@@ -784,11 +784,13 @@ func DeleteOldFile(username string) {
 func main() {
 
 	var username string
-	var noFalsePositives bool
+	var apikey string
 
 	usernameFlag := flag.String("u", "", "Username to search")
 	usernameFlagLong := flag.String("username", "", "Username to search")
 	noFalsePositivesFlag := flag.Bool("no-false-positives", false, "Do not show false positives")
+	breachDirectoryAPIKey := flag.String("b", "", "Search Breach Directory with an API Key")
+	breachDirectoryAPIKeyLong := flag.String("breach-directory-api-key", "", "Search Breach Directory with an API Key")
 
 	flag.Parse()
 
@@ -799,12 +801,6 @@ func main() {
 	} else {
 		fmt.Println("Usage: gosearch -u <username>\nIssues: https://github.com/ibnaleem/gosearch/issues")
 		os.Exit(1)
-	}
-
-	if *noFalsePositivesFlag {
-		noFalsePositives = true
-	} else {
-		noFalsePositives = false
 	}
 
 	DeleteOldFile(username)
@@ -824,14 +820,14 @@ func main() {
 	fmt.Println(":: Websites                              : ", len(data.Websites))
 	
 	// if the false positive flag is true, then specify that false positives are not shown
-	if noFalsePositives {
+	if *noFalsePositivesFlag {
 		fmt.Println(":: No False Positives                    : ", noFalsePositives)
 	}
 
 	fmt.Println(strings.Repeat("⎯", 85))
 
 	// if the false positive flag is not set, then show a message
-	if !noFalsePositives {
+	if !*noFalsePositivesFlag {
 		fmt.Println("[!] A yellow link indicates that I was unable to verify whether the username exists on the platform.")
 	}
 
@@ -848,8 +844,12 @@ func main() {
 	go HudsonRock(username, &wg)
 	wg.Wait()
 
-	if len(os.Args) == 3 {
-		apikey := os.Args[2]
+	if *breachDirectoryAPIKey != "" || *breachDirectoryAPIKeyLong != "" {
+		if *breachDirectoryAPIKey != "" {
+			apikey = *breachDirectoryAPIKey
+		} else {
+			apikey = *breachDirectoryAPIKeyLong
+		}
 		fmt.Println(strings.Repeat("⎯", 85))
 		strings.Repeat("⎯", 85)
 		wg.Add(1)

--- a/gosearch.go
+++ b/gosearch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"flag"
 	"sync"
 	"time"
 	"strings"
@@ -781,12 +782,31 @@ func DeleteOldFile(username string) {
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Println("Usage: gosearch <username>\nIssues: https://github.com/ibnaleem/gosearch/issues")
+
+	var username string
+	var noFalsePositives bool
+
+	usernameFlag := flag.String("u", "", "Username to search")
+	usernameFlagLong := flag.String("username", "", "Username to search")
+	noFalsePositivesFlag := flag.Bool("no-false-positives", false, "Do not show false positives")
+
+	flag.Parse()
+
+	if *usernameFlag != "" {
+		username = *usernameFlag
+	} else if *usernameFlagLong != "" {
+		username = *usernameFlagLong
+	} else {
+		fmt.Println("Usage: gosearch -u <username>\nIssues: https://github.com/ibnaleem/gosearch/issues")
 		os.Exit(1)
 	}
 
-	var username = os.Args[1]
+	if *noFalsePositivesFlag {
+		noFalsePositives = true
+	} else {
+		noFalsePositives = false
+	}
+
 	DeleteOldFile(username)
 	var wg sync.WaitGroup
 
@@ -802,8 +822,18 @@ func main() {
 	fmt.Println(strings.Repeat("⎯", 85))
 	fmt.Println(":: Username                              : ", username)
 	fmt.Println(":: Websites                              : ", len(data.Websites))
+	
+	// if the false positive flag is true, then specify that false positives are not shown
+	if noFalsePositives {
+		fmt.Println(":: No False Positives                    : ", noFalsePositives)
+	}
+
 	fmt.Println(strings.Repeat("⎯", 85))
-	fmt.Println("[!] A yellow link indicates that I was unable to verify whether the username exists on the platform.")
+
+	// if the false positive flag is not set, then show a message
+	if !noFalsePositives {
+		fmt.Println("[!] A yellow link indicates that I was unable to verify whether the username exists on the platform.")
+	}
 
 	start := time.Now()
 

--- a/gosearch.go
+++ b/gosearch.go
@@ -799,8 +799,12 @@ func main() {
 	} else if *usernameFlagLong != "" {
 		username = *usernameFlagLong
 	} else {
-		fmt.Println("Usage: gosearch -u <username>\nIssues: https://github.com/ibnaleem/gosearch/issues")
-		os.Exit(1)
+		if len(os.Args) > 1 {
+			username = os.Args[1]
+		} else {
+			fmt.Println("Usage: gosearch -u <username>\nIssues: https://github.com/ibnaleem/gosearch/issues")
+			os.Exit(1)
+		}
 	}
 
 	DeleteOldFile(username)

--- a/gosearch.go
+++ b/gosearch.go
@@ -821,7 +821,7 @@ func main() {
 	
 	// if the false positive flag is true, then specify that false positives are not shown
 	if *noFalsePositivesFlag {
-		fmt.Println(":: No False Positives                    : ", noFalsePositives)
+		fmt.Println(":: No False Positives                    : ", *noFalsePositivesFlag)
 	}
 
 	fmt.Println(strings.Repeat("⎯", 85))


### PR DESCRIPTION
The expanding scope of GoSearch's [`data.json`](https://github.com/ibnaleem/gosearch/blob/main/data.json) introduces an increasing volume of unresolved username validations across platforms. These instances are not strictly false positives but are operationally equivalent due to GoSearch’s persistent inclusion of unverified results in outputs.  

**Optimisation via CLI Flags:**  
Implemented the Go `flag` package to introduce structured command-line arguments:  
- `-u`/`--username`: Username to search  
- `-b`/`--breach-directory`: Search Breach Directory with an API Key.  
- `--no-false-positives`: Do not show false positives  

**Username Handling Logic:**  
If `-u`/`--username` is omitted, the system defaults to the second CLI argument (see [5cd8c2a](https://github.com/ibnaleem/gosearch/commit/5cd8c2a7d0ad6a502e9913603beb4fb3299a253b)):  
```go
if *usernameFlag != "" {
    username = *usernameFlag
} else if *usernameFlagLong != "" {
    username = *usernameFlagLong
} else {
    if len(os.Args) > 1 {
        username = os.Args[1] 
    } else {
        fmt.Println("Usage: gosearch -u <username>\nIssues: https://github.com/ibnaleem/gosearch/issues")
        os.Exit(1)
    }
}
```  

**Output Behavior:**  
- **Default:** Unverified results marked with `[?]` and yellow highlighting.  
  ```  
  [?] Twitter/X: https://twitter.com/mrrobot  
  ...  
  [+] Lichess: https://lichess.org/@/mrrobot  
  ```  
- **`--no-false-positives`:** Strictly outputs confirmed (`[+]`) entries.  
  ```  
  [+] Lichess: https://lichess.org/@/mrrobot  
  [+] All My Links: https://allmylinks.com/mrrobot
  .... 
  ```  

**Rationale:** The `--no-false-positives` flag eliminates noise from unvalidated data, ensuring outputs are actionable and reliable. This adjustment aligns with efficiency-driven objectives, prioritising quality over quantity.