### PR TITLE
feat/gravatar wire

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ const ASCII = `
 
 const DefaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:149.0) Gecko/20100101 Firefox/149.0"
 
-const VERSION = "v2.0.0"
+const VERSION = "v2.0.1"
 
 var TLSConfig = &tls.Config{
 	MinVersion: tls.VersionTLS12,

--- a/internal/modules/gravatar/gravatar.go
+++ b/internal/modules/gravatar/gravatar.go
@@ -37,7 +37,7 @@ type GravatarUserAccounts struct {
 func SearchGravatar(username string) {
 	theme.Yellow("[*] Searching Gravatar for ", username, "...").Println()
 
-	url := fmt.Sprintf("https://gravatar.com/users/%s.json", username)
+	url := fmt.Sprintf("https://gravatar.com/%s.json", username)
 	resp, err := http.Get(url)
 	if err != nil {
 		theme.Redf("[-] Error fetching Gravatar data: %v", err).Println()

--- a/internal/modules/gravatar/gravatar.go
+++ b/internal/modules/gravatar/gravatar.go
@@ -12,13 +12,13 @@ type GravatarResponse struct {
 }
 
 type GravatarUser struct {
-	EmailHash        string               `json:"hash"`
-	Username         string               `json:"requestHash"`
-	PreferredUsername string               `json:"preferredUsername"`
-	DisplayName      string               `json:"displayName"`
-	AboutMe          string               `json:"aboutMe"`
-	Emails           []GravatarUserEmails   `json:"emails"`
-	Accounts         []GravatarUserAccounts `json:"accounts"`
+	EmailHash         string                 `json:"hash"`
+	Username          string                 `json:"requestHash"`
+	PreferredUsername string                 `json:"preferredUsername"`
+	DisplayName       string                 `json:"displayName"`
+	AboutMe           string                 `json:"aboutMe"`
+	Emails            []GravatarUserEmails   `json:"emails"`
+	Accounts          []GravatarUserAccounts `json:"accounts"`
 }
 
 type GravatarUserEmails struct {
@@ -32,57 +32,55 @@ type GravatarUserAccounts struct {
 }
 
 func DisplayGravatarUserInfo(user GravatarUser) {
-	theme.Greenf("[+] Gravatar username found: %s", user.Username)
+	theme.Greenf("[+] Gravatar username found: %s", user.Username).Println()
 
-	if user.Username != user.PreferredUsername {
-		theme.Greenf("[+] ↳ Preferred username: %s", user.PreferredUsername)
+	if user.DisplayName != "" {
+		theme.Greenf("[+] ↳ Display name: %s", user.DisplayName).Println()
 	}
 
-	theme.Greenf("[+] ↳ About Me: %s", user.AboutMe)
+	if user.PreferredUsername != "" && user.Username != user.PreferredUsername {
+		theme.Greenf("[+] ↳ Preferred username: %s", user.PreferredUsername).Println()
+	}
+
+	if user.AboutMe != "" {
+		theme.Greenf("[+] ↳ About Me: %s", user.AboutMe).Println()
+	}
 
 	if len(user.Emails) == 0 {
-		fmt.Println(strings.Repeat("-", 85))
-		theme.Greenf("[+] ↳ SHA256 Email Hash: %s", user.EmailHash)
-		theme.Green("[+] ↳ Hashcat command to crack this hash:")
-		theme.Greenf("[+] ↳ hashcat -m 1400 -a 0 %s facebook-firstnames.txt -r rules/MISC/emails-combined.rule --bitmap-max 28", user.EmailHash)
-		theme.Green("[+] ↳ Hashcat rules can be found @ https://github.com/ibnaleem/rules")
-		theme.Green("[+] ↳ Wordlists can be found @ https://weakpass.com/wordlists?name=name")
-		theme.Green("[+] ↳ You could also submit this hash to Hashmob.net if you cannot crack it")
-		fmt.Println(strings.Repeat("-", 85))
-	}
-
-	if len(user.Emails) > 1 {
-		fmt.Println(strings.Repeat("-", 85))
-		theme.Greenf("[+] %d Emails found for %s:", len(user.Emails), user.Username)
-		for _, email := range user.Emails {
-			theme.Greenf("[+] ↳ %s", email.Email)
-		}
-		fmt.Println(strings.Repeat("-", 85))
+		fmt.Println(strings.Repeat("⎯", 85))
+		theme.Greenf("[+] ↳ SHA256 Email Hash: %s", user.EmailHash).Println()
+		theme.Green("[+] ↳ Hashcat command to crack this hash:").Println()
+		theme.Greenf("[+] ↳ hashcat -m 1400 -a 0 %s facebook-firstnames.txt -r rules/MISC/emails-combined.rule --bitmap-max 28", user.EmailHash).Println()
+		theme.Green("[+] ↳ Hashcat rules can be found @ https://github.com/ibnaleem/rules").Println()
+		theme.Green("[+] ↳ Wordlists can be found @ https://weakpass.com/wordlists?name=name").Println()
+		theme.Green("[+] ↳ You could also submit this hash to Hashmob.net if you cannot crack it").Println()
+		fmt.Println(strings.Repeat("⎯", 85))
+	} else if len(user.Emails) == 1 {
+		theme.Greenf("[+] ↳ Email: %s", user.Emails[0].Email).Println()
 	} else {
-		theme.Greenf("[+] Email found for %s: %s", user.Username, user.Emails[0].Email)
+		fmt.Println(strings.Repeat("⎯", 85))
+		theme.Greenf("[+] %d emails found for %s:", len(user.Emails), user.Username).Println()
+		for _, email := range user.Emails {
+			theme.Greenf("[+] ↳ %s", email.Email).Println()
+		}
+		fmt.Println(strings.Repeat("⎯", 85))
 	}
 
 	if len(user.Accounts) == 0 {
 		return
 	}
 
-	if len(user.Accounts) > 1 {
-		fmt.Println(strings.Repeat("-", 85))
-		theme.Greenf("[+] %d accounts found for %s:", len(user.Accounts), user.Username)
-		for _, account := range user.Accounts {
-			fmt.Println(strings.Repeat("-", 85))
-			theme.Greenf("[+] ↳ Platform: %s", account.Name)
-			theme.Greenf("[+] ↳ Account URL: %s", account.URL)
-			theme.Greenf("[+] ↳ Username: %s", account.Username)
-			fmt.Println(strings.Repeat("-", 85))
-		}
+	fmt.Println(strings.Repeat("⎯", 85))
+	if len(user.Accounts) == 1 {
+		theme.Greenf("[+] An account was found for %s:", user.Username).Println()
 	} else {
-		fmt.Println(strings.Repeat("-", 85))
-		theme.Greenf("[+] An account was found for %s:", user.Username)
-		for _, account := range user.Accounts {
-			theme.Greenf("[+] ↳ Platform: %s", account.Name)
-			theme.Greenf("[+] ↳ Account URL: %s", account.URL)
-			theme.Greenf("[+] ↳ Username: %s", account.Username)
-		}
+		theme.Greenf("[+] %d accounts found for %s:", len(user.Accounts), user.Username).Println()
 	}
+	for _, account := range user.Accounts {
+		fmt.Println(strings.Repeat("⎯", 85))
+		theme.Greenf("[+] ↳ Platform: %s", account.Name).Println()
+		theme.Greenf("[+] ↳ Account URL: %s", account.URL).Println()
+		theme.Greenf("[+] ↳ Username: %s", account.Username).Println()
+	}
+	fmt.Println(strings.Repeat("⎯", 85))
 }

--- a/internal/modules/gravatar/gravatar.go
+++ b/internal/modules/gravatar/gravatar.go
@@ -1,7 +1,10 @@
 package gravatar
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/ibnaleem/gosearch/internal/theme"
@@ -29,6 +32,47 @@ type GravatarUserAccounts struct {
 	URL      string `json:"url"`
 	Username string `json:"username"`
 	Name     string `json:"name"`
+}
+
+func SearchGravatar(username string) {
+	theme.Yellow("[*] Searching Gravatar for ", username, "...").Println()
+
+	url := fmt.Sprintf("https://gravatar.com/users/%s.json", username)
+	resp, err := http.Get(url)
+	if err != nil {
+		theme.Redf("[-] Error fetching Gravatar data: %v", err).Println()
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		theme.Red("[-] No Gravatar profile found for ", username).Println()
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		theme.Redf("[-] Gravatar returned status %d", resp.StatusCode).Println()
+		return
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		theme.Redf("[-] Error reading Gravatar response: %v", err).Println()
+		return
+	}
+
+	var response GravatarResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		theme.Redf("[-] Error parsing Gravatar response: %v", err).Println()
+		return
+	}
+
+	if len(response.Entry) == 0 {
+		theme.Red("[-] No Gravatar profile found for ", username).Println()
+		return
+	}
+
+	DisplayGravatarUserInfo(response.Entry[0])
 }
 
 func DisplayGravatarUserInfo(user GravatarUser) {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ibnaleem/gosearch/internal/config"
 	github "github.com/ibnaleem/gosearch/internal/modules/github"
+	"github.com/ibnaleem/gosearch/internal/modules/gravatar"
 	"github.com/ibnaleem/gosearch/internal/models"
 	"github.com/ibnaleem/gosearch/internal/theme"
 	"github.com/ibnaleem/gosearch/internal/utils"
@@ -304,6 +305,12 @@ func Search(data models.Data, username string, noFalsePositives bool, wg *sync.W
 				}
 				fmt.Println()
 				github.DisplayGitHubInfo(githubUser, username)
+				return
+			}
+
+			if strings.TrimSpace(website.Name) == "Gravatar" {
+				fmt.Println()
+				gravatar.SearchGravatar(username)
 				return
 			}
 


### PR DESCRIPTION
The Gravatar module existed in name only. It had structs and a display function but nothing that actually made an HTTP request, so running GoSearch against any Gravatar entry was silently doing nothing.

Two things needed fixing. The fetch itself was hitting the wrong endpoint (`/users/<name>.json` instead of `/<name>.json`), and `DisplayGravatarUserInfo` had a different problem entirely: every `theme` call was missing `.Println()`, so even if you managed to get data back, none of it would print. On top of that the email and accounts logic was duplicated across several if/else branches with inconsistent separators (mixing `-` with the `⎯` used everywhere else), and the display name field was never shown at all.

Both are fixed. `SearchGravatar` now fetches from the right URL, parses the response, and hands off to the display function. The display function has been collapsed into clean single-pass logic that handles zero/one/many emails and accounts without repeating itself.

The module is also wired into `search.go` now. When the search loop hits a site entry named `Gravatar`, it calls `SearchGravatar` directly rather than falling through to the generic matcher.

Bumped to v2.0.1.